### PR TITLE
Fix socketio connection from old clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const DEFAULT_LIVE_UPDATE_PORT = 8088;
 function startStaticPropsWatcher({ port }) {
     console.log(`[data-listener] create socket.io on port ${port} with namespace '/nextjs-live-updates'`);
     const io = socketIO(port, {
+        allowEIO3: true,
         cors: {
             origin: true
         }


### PR DESCRIPTION
This PR adds support for legacy clients, such as v2 to connect to updated v4 socket.io server by introducing flag to socketIo server opts

https://socket.io/docs/v4/server-initialization/#allowEIO3