### PR TITLE
Add optional cacheFile param to getData method.

### DIFF
--- a/lib/data-client.js
+++ b/lib/data-client.js
@@ -10,28 +10,29 @@ class SourcebitDataClient {
         // https://github.com/zeit/next.js/issues/10933
     }
 
-    async getData() {
+    async getData(cacheFile) {
         // For now, we are reading the changes from filesystem until re-import
         // of this module will be fixed: https://github.com/zeit/next.js/issues/10933
         // TODO: DEFAULT_FILE_CACHE_PATH won't work if default cache file path
         //   was changed, but also can't access the specified path because
         //   nextjs re-imports the whole module when this method is called
+        const cacheFilePath = cacheFile === undefined? DEFAULT_FILE_CACHE_PATH : cacheFile;
         const cacheFileExists = new Promise((resolve, reject) => {
             const retryDelay = 500;
             const maxNumOfRetries = 10;
             let numOfRetries = 0;
             const checkPathExists = async () => {
-                const pathExists = await fse.pathExists(DEFAULT_FILE_CACHE_PATH);
+                const pathExists = await fse.pathExists(cacheFilePath);
                 if (!pathExists && numOfRetries < maxNumOfRetries) {
                     numOfRetries += 1;
                     console.log(
-                        `error in sourcebitDataClient.getData(), cache file '${DEFAULT_FILE_CACHE_PATH}' was not found, waiting ${retryDelay}ms and retry #${numOfRetries}`
+                        `error in sourcebitDataClient.getData(), cache file '${cacheFilePath}' was not found, waiting ${retryDelay}ms and retry #${numOfRetries}`
                     );
                     setTimeout(checkPathExists, retryDelay);
                 } else if (!pathExists) {
                     reject(
                         new Error(
-                            `sourcebitDataClient of the sourcebit-target-next plugin did not find '${DEFAULT_FILE_CACHE_PATH}' file. Please check that other Sourcebit plugins are executed successfully.`
+                            `sourcebitDataClient of the sourcebit-target-next plugin did not find '${cacheFilePath}' file. Please check that other Sourcebit plugins are executed successfully.`
                         )
                     );
                 } else {
@@ -43,11 +44,11 @@ class SourcebitDataClient {
 
         await cacheFileExists;
 
-        return fse.readJson(DEFAULT_FILE_CACHE_PATH);
+        return fse.readJson(cacheFilePath);
     }
 
-    async getStaticPaths() {
-        const data = await this.getData();
+    async getStaticPaths(cacheFile) {
+        const data = await this.getData(cacheFile);
         let paths = _.map(data.pages, (page) => page.path).filter(Boolean);
         if (process.env.NODE_ENV === 'development') {
             paths = paths.concat(_.map(paths, (pagePath) => pagePath + (pagePath !== '/' ? '/' : '')));
@@ -55,8 +56,8 @@ class SourcebitDataClient {
         return paths;
     }
 
-    async getStaticPropsForPageAtPath(pagePath) {
-        const data = await this.getData();
+    async getStaticPropsForPageAtPath(pagePath, cacheFile) {
+        const data = await this.getData(cacheFile);
         return this.getPropsFromCMSDataForPagePath(data, pagePath);
     }
 


### PR DESCRIPTION
Add optional cacheFile param to getData method.

Reasons: monorepo support

I am not so convinced this is the best way to go about this, but it was unclear to me how else to specify the cache file path in a clean ("side effect free") way. I wouldn't mind reworking this if there's something I missed.

Cheers!